### PR TITLE
Add Support for PHP 8.2

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -1,13 +1,14 @@
 name: Coding Standards
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
+    branches:
+      - develop
+    types: [opened, synchronize, reopened, ready_for_review]
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 6 * * 0' # Run once per week at 6am UTC on Sundays.
 
 jobs:
   coding-standards:
+    if: github.event.pull_request.draft == false
     uses: alleyinteractive/.github/.github/workflows/php-coding-standards.yml@main

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,13 +1,21 @@
 name: Testing Suite
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
+    branches:
+      - develop
+    types: [opened, synchronize, reopened, ready_for_review]
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 6 * * 0' # Run once per week at 6am UTC on Sundays.
 
 jobs:
-  unit-tests:
+  php-tests:
+    if: github.event.pull_request.draft == false
+    strategy:
+      matrix:
+        php: [8.0, 8.1, 8.2]
+        wordpress: ["latest"]
     uses: alleyinteractive/.github/.github/workflows/php-tests.yml@main
+    with:
+      php: ${{ matrix.php }}
+      wordpress: ${{ matrix.wordpress }}

--- a/composer.json
+++ b/composer.json
@@ -15,13 +15,13 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.0|^8.1|^8.2",
         "alleyinteractive/composer-wordpress-autoloader": "^1.0"
     },
     "require-dev": {
-        "alleyinteractive/alley-coding-standards": "^1.0",
-        "mantle-framework/testkit": "^0.9",
-        "nunomaduro/collision": "^5.0"
+        "alleyinteractive/alley-coding-standards": "^2.0",
+        "mantle-framework/testkit": "^0.12",
+        "nunomaduro/collision": "^6.0"
     },
     "config": {
         "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "alleyinteractive/wp-block-converter",
     "description": "Convert HTML into Gutenberg Blocks with PHP",
+    "version": "1.1.0",
     "type": "library",
     "keywords": [
         "alleyinteractive",

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
     "name": "alleyinteractive/wp-block-converter",
     "description": "Convert HTML into Gutenberg Blocks with PHP",
-    "version": "1.1.0",
     "type": "library",
     "keywords": [
         "alleyinteractive",


### PR DESCRIPTION
- Adds explicit support for PHP 8.0, 8.1, 8.2 and adds tests for each version via a matrix
- Updates dependencies to latest supported versions
- Changes workflows to not run on push, only on PRs and on a schedule, reduces the schedule to once per week, and never on draft PRs.