### PR TITLE
Update docs to use correct conversion method

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ Use this package like so to convert HTML into Gutenberg Blocks:
 ```php
 use Alley\WP\Block_Converter\Block_Converter;
 
-$converter = new Block_Converter();
+$converter = new Block_Converter( '<p>Some HTML</p>' );
 
-$blocks = $converter->convert( '<p>Some HTML</p>' );
+$blocks = $converter->convert();
 ```
 
 ### Filtering the Blocks
@@ -63,9 +63,7 @@ Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed re
 
 ## Credits
 
-This project is actively maintained by [Alley
-Interactive](https://github.com/alleyinteractive). Like what you see? [Come work
-with us](https://alley.com/careers/).
+This project is actively maintained by [Alley Interactive](https://github.com/alleyinteractive). Like what you see? [Come work with us](https://alley.com/careers/).
 
 - [Sean Fisher](https://github.com/srtfisher)
 - [All Contributors](../../contributors)


### PR DESCRIPTION
- Fixes a bug in the README where the method for converting blocks was wrong (HTML needs to be passed to the constructor, not the convert method).