### PR TITLE
Issue-17: x.com urls do not get embedded properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `WP Block Converter` will be documented in this file.
 
+## 1.3.1
+
+- Fixes embeds of x.com urls (instead of twitter.com)
+
 ## 1.3.0
 
 - Adds macro support to the converter, allowing for custom tags to be added to the

--- a/src/class-block-converter.php
+++ b/src/class-block-converter.php
@@ -170,6 +170,9 @@ class Block_Converter {
 		$content = static::get_node_html( $node );
 
 		if ( ! empty( filter_var( $node->textContent, FILTER_VALIDATE_URL ) ) ) {
+			if ( \str_contains( $node->textContent, '//x.com' ) || \str_contains( $node->textContent, '//www.x.com' ) ) {
+				$node->textContent = str_replace( 'x.com', 'twitter.com', $node->textContent );
+			}
 			// Instagram and Facebook embeds require an api key to retrieve oEmbed data.
 			if ( \str_contains( $node->textContent, 'instagram.com' ) ) {
 				return $this->instagram_embed( $node->textContent );

--- a/tests/feature/test-block-converter.php
+++ b/tests/feature/test-block-converter.php
@@ -174,12 +174,42 @@ class Test_Block_Block_Converter extends Test_Case {
         );
     }
 
-    public function test_x_url_to_embed() {
-        $this->fake_request( 'https://publish.twitter.com/oembed?url=https%3A%2F%2Ftwitter.com%2Falleyco%2Fstatus%2F1679189879086018562' )
+    public function test_twitter_url_to_embed() {
+        $this->fake_request( 'https://publish.twitter.com/oembed?maxwidth=500&maxheight=750&url=https%3A%2F%2Ftwitter.com%2Falleyco%2Fstatus%2F1679189879086018562&dnt=1&format=json' )
             ->with_response_code( 200 )
             ->with_body( '{"url":"https:\/\/twitter.com\/alleyco\/status\/1679189879086018562","author_name":"Alley","author_url":"https:\/\/twitter.com\/alleyco","html":"\u003Cblockquote class=\"twitter-tweet\"\u003E\u003Cp lang=\"en\" dir=\"ltr\"\u003EWe’re a full-service digital agency with the foresight, perspective, and grit to power your brightest ideas and build solutions for your most evasive problems. Learn more about our services here:\u003Ca href=\"https:\/\/t.co\/8zZ5zP1Oyc\"\u003Ehttps:\/\/t.co\/8zZ5zP1Oyc\u003C\/a\u003E\u003C\/p\u003E&mdash; Alley (@alleyco) \u003Ca href=\"https:\/\/twitter.com\/alleyco\/status\/1679189879086018562?ref_src=twsrc%5Etfw\"\u003EJuly 12, 2023\u003C\/a\u003E\u003C\/blockquote\u003E\n\u003Cscript async src=\"https:\/\/platform.twitter.com\/widgets.js\" charset=\"utf-8\"\u003E\u003C\/script\u003E\n\n","width":550,"height":null,"type":"rich","cache_age":"3153600000","provider_name":"Twitter","provider_url":"https:\/\/twitter.com","version":"1.0"}' );
 
         $converter = new Block_Converter( '<p>https://twitter.com/alleyco/status/1679189879086018562</p>' );
+        $block     = $converter->convert();
+
+        $this->assertNotEmpty( $block );
+        $this->assertSame(
+            '<!-- wp:embed {"url":"https://twitter.com/alleyco/status/1679189879086018562","type":"rich","providerNameSlug":"twitter","responsive":true} --><figure class="wp-block-embed is-type-rich is-provider-twitter wp-block-embed-twitter"><div class="wp-block-embed__wrapper">https://twitter.com/alleyco/status/1679189879086018562</div></figure><!-- /wp:embed -->',
+            $block,
+        );
+    }
+
+    public function test_x_url_to_embed() {
+        $this->fake_request( 'https://publish.x.com/oembed?url=https%3A%2F%2Fx.com%2Falleyco%2Fstatus%2F1679189879086018562' )
+            ->with_response_code( 200 )
+            ->with_body( '{"url":"https:\/\/twitter.com\/alleyco\/status\/1679189879086018562","author_name":"Alley","author_url":"https:\/\/twitter.com\/alleyco","html":"\u003Cblockquote class=\"twitter-tweet\"\u003E\u003Cp lang=\"en\" dir=\"ltr\"\u003EWe’re a full-service digital agency with the foresight, perspective, and grit to power your brightest ideas and build solutions for your most evasive problems. Learn more about our services here:\u003Ca href=\"https:\/\/t.co\/8zZ5zP1Oyc\"\u003Ehttps:\/\/t.co\/8zZ5zP1Oyc\u003C\/a\u003E\u003C\/p\u003E&mdash; Alley (@alleyco) \u003Ca href=\"https:\/\/twitter.com\/alleyco\/status\/1679189879086018562?ref_src=twsrc%5Etfw\"\u003EJuly 12, 2023\u003C\/a\u003E\u003C\/blockquote\u003E\n\u003Cscript async src=\"https:\/\/platform.twitter.com\/widgets.js\" charset=\"utf-8\"\u003E\u003C\/script\u003E\n\n","width":550,"height":null,"type":"rich","cache_age":"3153600000","provider_name":"Twitter","provider_url":"https:\/\/twitter.com","version":"1.0"}' );
+
+        $converter = new Block_Converter( '<p>https://x.com/alleyco/status/1679189879086018562</p>' );
+        $block     = $converter->convert();
+
+        $this->assertNotEmpty( $block );
+        $this->assertSame(
+            '<!-- wp:embed {"url":"https://twitter.com/alleyco/status/1679189879086018562","type":"rich","providerNameSlug":"twitter","responsive":true} --><figure class="wp-block-embed is-type-rich is-provider-twitter wp-block-embed-twitter"><div class="wp-block-embed__wrapper">https://twitter.com/alleyco/status/1679189879086018562</div></figure><!-- /wp:embed -->',
+            $block,
+        );
+    }
+
+    public function test_linked_x_url_to_embed() {
+        $this->fake_request( 'https://publish.x.com/oembed?url=https%3A%2F%2Fx.com%2Falleyco%2Fstatus%2F1679189879086018562' )
+            ->with_response_code( 200 )
+            ->with_body( '{"url":"https:\/\/twitter.com\/alleyco\/status\/1679189879086018562","author_name":"Alley","author_url":"https:\/\/twitter.com\/alleyco","html":"\u003Cblockquote class=\"twitter-tweet\"\u003E\u003Cp lang=\"en\" dir=\"ltr\"\u003EWe’re a full-service digital agency with the foresight, perspective, and grit to power your brightest ideas and build solutions for your most evasive problems. Learn more about our services here:\u003Ca href=\"https:\/\/t.co\/8zZ5zP1Oyc\"\u003Ehttps:\/\/t.co\/8zZ5zP1Oyc\u003C\/a\u003E\u003C\/p\u003E&mdash; Alley (@alleyco) \u003Ca href=\"https:\/\/twitter.com\/alleyco\/status\/1679189879086018562?ref_src=twsrc%5Etfw\"\u003EJuly 12, 2023\u003C\/a\u003E\u003C\/blockquote\u003E\n\u003Cscript async src=\"https:\/\/platform.twitter.com\/widgets.js\" charset=\"utf-8\"\u003E\u003C\/script\u003E\n\n","width":550,"height":null,"type":"rich","cache_age":"3153600000","provider_name":"Twitter","provider_url":"https:\/\/twitter.com","version":"1.0"}' );
+
+        $converter = new Block_Converter( '<p><a href="https://x.com/alleyco/status/1679189879086018562">https://x.com/alleyco/status/1679189879086018562</a></p>' );
         $block     = $converter->convert();
 
         $this->assertNotEmpty( $block );


### PR DESCRIPTION
### Description of the bug

links to x.com tweets instead of twitter.com don't get embedded properly. This issue has been addressed by ensuring that URLs from x.com are properly embedded similar to those from twitter.com.

### Steps To Reproduce

try converting the following:
`<p>https://x.com/alleyco/status/1679189879086018562</p>`

### Additional Information

A changelog entry has been added to document the changes made to resolve this issue.