### PR TITLE
Issue-19: embeds must have a line break before and after the url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to `WP Block Converter` will be documented in this file.
 ## 1.3.2
 
 - Preserve new lines in embed blocks. They are required for proper front end rendering.
+- Fix aspect ratio calculation when height and width are percentages - which fixes TikTok embeds.
 
 ## 1.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `WP Block Converter` will be documented in this file.
 
+## 1.3.2
+
+- Preserve new lines in embed blocks. They are required for proper front end rendering.
+
 ## 1.3.1
 
 - Fixes embeds of x.com urls (instead of twitter.com)

--- a/src/class-block-converter.php
+++ b/src/class-block-converter.php
@@ -275,7 +275,7 @@ class Block_Converter {
 		$data = _wp_oembed_get_object()->get_data( $url, [] );
 
 		$aspect_ratio = '';
-		if ( ! empty( $data->height ) && ! empty( $data->width ) ) {
+		if ( ! empty( $data->height ) && ! empty( $data->width ) && is_numeric( $data->height ) && is_numeric( $data->width ) ) {
 			if ( 1.78 === round( $data->width / $data->height, 2 ) ) {
 				$aspect_ratio = '16-9';
 			}

--- a/src/class-block-converter.php
+++ b/src/class-block-converter.php
@@ -67,6 +67,7 @@ class Block_Converter {
 			}
 
 			// Merge the block into the HTML collection.
+
 			$html[] = $this->minify_block( (string) $tag_block );
 		}
 
@@ -446,8 +447,13 @@ class Block_Converter {
 	 * @return string
 	 */
 	protected function minify_block( $block ) {
-		if ( preg_match( '/(\s){2,}/s', $block ) === 1 ) {
-			return preg_replace( '/(\s){2,}/s', '', $block );
+		if ( \str_contains( $block, 'wp-block-embed' ) ) {
+			$pattern = '/(\h){2,}/s';
+		} else {
+			$pattern = '/(\s){2,}/s';
+		}
+		if ( preg_match( $pattern, $block ) === 1 ) {
+			return preg_replace( $pattern, '', $block );
 		}
 
 		return $block;

--- a/tests/feature/test-block-converter.php
+++ b/tests/feature/test-block-converter.php
@@ -169,7 +169,9 @@ class Test_Block_Block_Converter extends Test_Case {
 
         $this->assertNotEmpty( $block );
         $this->assertSame(
-			'<!-- wp:embed {"url":"https://www.youtube.com/watch?v=dQw4w9WgXcQ","type":"video","providerNameSlug":"youtube","responsive":true,"className":"wp-embed-aspect-16-9 wp-has-aspect-ratio"} --><figure class="wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">https://www.youtube.com/watch?v=dQw4w9WgXcQ</div></figure><!-- /wp:embed -->',
+			'<!-- wp:embed {"url":"https://www.youtube.com/watch?v=dQw4w9WgXcQ","type":"video","providerNameSlug":"youtube","responsive":true,"className":"wp-embed-aspect-16-9 wp-has-aspect-ratio"} --><figure class="wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
+https://www.youtube.com/watch?v=dQw4w9WgXcQ
+</div></figure><!-- /wp:embed -->',
 			$block,
         );
     }
@@ -184,7 +186,9 @@ class Test_Block_Block_Converter extends Test_Case {
 
         $this->assertNotEmpty( $block );
         $this->assertSame(
-            '<!-- wp:embed {"url":"https://twitter.com/alleyco/status/1679189879086018562","type":"rich","providerNameSlug":"twitter","responsive":true} --><figure class="wp-block-embed is-type-rich is-provider-twitter wp-block-embed-twitter"><div class="wp-block-embed__wrapper">https://twitter.com/alleyco/status/1679189879086018562</div></figure><!-- /wp:embed -->',
+            '<!-- wp:embed {"url":"https://twitter.com/alleyco/status/1679189879086018562","type":"rich","providerNameSlug":"twitter","responsive":true} --><figure class="wp-block-embed is-type-rich is-provider-twitter wp-block-embed-twitter"><div class="wp-block-embed__wrapper">
+https://twitter.com/alleyco/status/1679189879086018562
+</div></figure><!-- /wp:embed -->',
             $block,
         );
     }
@@ -199,7 +203,9 @@ class Test_Block_Block_Converter extends Test_Case {
 
         $this->assertNotEmpty( $block );
         $this->assertSame(
-            '<!-- wp:embed {"url":"https://twitter.com/alleyco/status/1679189879086018562","type":"rich","providerNameSlug":"twitter","responsive":true} --><figure class="wp-block-embed is-type-rich is-provider-twitter wp-block-embed-twitter"><div class="wp-block-embed__wrapper">https://twitter.com/alleyco/status/1679189879086018562</div></figure><!-- /wp:embed -->',
+            '<!-- wp:embed {"url":"https://twitter.com/alleyco/status/1679189879086018562","type":"rich","providerNameSlug":"twitter","responsive":true} --><figure class="wp-block-embed is-type-rich is-provider-twitter wp-block-embed-twitter"><div class="wp-block-embed__wrapper">
+https://twitter.com/alleyco/status/1679189879086018562
+</div></figure><!-- /wp:embed -->',
             $block,
         );
     }
@@ -214,7 +220,9 @@ class Test_Block_Block_Converter extends Test_Case {
 
         $this->assertNotEmpty( $block );
         $this->assertSame(
-            '<!-- wp:embed {"url":"https://twitter.com/alleyco/status/1679189879086018562","type":"rich","providerNameSlug":"twitter","responsive":true} --><figure class="wp-block-embed is-type-rich is-provider-twitter wp-block-embed-twitter"><div class="wp-block-embed__wrapper">https://twitter.com/alleyco/status/1679189879086018562</div></figure><!-- /wp:embed -->',
+            '<!-- wp:embed {"url":"https://twitter.com/alleyco/status/1679189879086018562","type":"rich","providerNameSlug":"twitter","responsive":true} --><figure class="wp-block-embed is-type-rich is-provider-twitter wp-block-embed-twitter"><div class="wp-block-embed__wrapper">
+https://twitter.com/alleyco/status/1679189879086018562
+</div></figure><!-- /wp:embed -->',
             $block,
         );
     }
@@ -225,7 +233,9 @@ class Test_Block_Block_Converter extends Test_Case {
 
         $this->assertNotEmpty( $block );
         $this->assertSame(
-            '<!-- wp:embed {"url":"https://www.instagram.com/p/CSpmSvAphdf/","type":"rich","providerNameSlug":"instagram","responsive":true} --><figure class="wp-block-embed is-type-rich is-provider-instagram wp-block-embed-instagram"><div class="wp-block-embed__wrapper">https://www.instagram.com/p/CSpmSvAphdf/</div></figure><!-- /wp:embed -->',
+            '<!-- wp:embed {"url":"https://www.instagram.com/p/CSpmSvAphdf/","type":"rich","providerNameSlug":"instagram","responsive":true} --><figure class="wp-block-embed is-type-rich is-provider-instagram wp-block-embed-instagram"><div class="wp-block-embed__wrapper">
+https://www.instagram.com/p/CSpmSvAphdf/
+</div></figure><!-- /wp:embed -->',
             $block,
         );
     }
@@ -236,7 +246,9 @@ class Test_Block_Block_Converter extends Test_Case {
 
         $this->assertNotEmpty( $block );
         $this->assertSame(
-            '<!-- wp:embed {"url":"https://www.facebook.com/sesametheopossum/posts/1329405240877426","type":"rich","providerNameSlug":"embed-handler","responsive":true,"previewable":false} --><figure class="wp-block-embed is-type-rich is-provider-embed-handler wp-block-embed-embed-handler"><div class="wp-block-embed__wrapper">https://www.facebook.com/sesametheopossum/posts/1329405240877426</div></figure><!-- /wp:embed -->',
+            '<!-- wp:embed {"url":"https://www.facebook.com/sesametheopossum/posts/1329405240877426","type":"rich","providerNameSlug":"embed-handler","responsive":true,"previewable":false} --><figure class="wp-block-embed is-type-rich is-provider-embed-handler wp-block-embed-embed-handler"><div class="wp-block-embed__wrapper">
+https://www.facebook.com/sesametheopossum/posts/1329405240877426
+</div></figure><!-- /wp:embed -->',
             $block,
         );
     }

--- a/tests/feature/test-block-converter.php
+++ b/tests/feature/test-block-converter.php
@@ -18,103 +18,103 @@ use DOMNode;
  * @group block
  */
 class Test_Block_Block_Converter extends Test_Case {
-    public function test_convert_content_to_blocks() {
-        $html      = '<p>Content to migrate</p><h1>Heading 01</h1>';
-        $converter = new Block_Converter( $html );
-        $block     = $converter->convert();
+	public function test_convert_content_to_blocks() {
+		$html      = '<p>Content to migrate</p><h1>Heading 01</h1>';
+		$converter = new Block_Converter( $html );
+		$block     = $converter->convert();
 
-        $this->assertNotEmpty( $block );
-        $this->assertEquals(
+		$this->assertNotEmpty( $block );
+		$this->assertEquals(
 '<!-- wp:paragraph --><p>Content to migrate</p><!-- /wp:paragraph -->
 
 <!-- wp:heading {"level":1} --><h1>Heading 01</h1><!-- /wp:heading -->',
 			$block,
-        );
-    }
+		);
+	}
 
-    public function test_convert_heading_h1_to_block() {
-        $html = '<h1>Another content</h1>';
-        $converter = new Block_Converter( $html );
-        $block     = $converter->convert();
+	public function test_convert_heading_h1_to_block() {
+		$html = '<h1>Another content</h1>';
+		$converter = new Block_Converter( $html );
+		$block     = $converter->convert();
 
-        $this->assertNotEmpty( $block );
-        $this->assertSame(
+		$this->assertNotEmpty( $block );
+		$this->assertSame(
 			'<!-- wp:heading {"level":1} -->' . $html . '<!-- /wp:heading -->',
-            $block,
-        );
-    }
+			$block,
+		);
+	}
 
-    public function test_convert_heading_h2_to_block() {
-        $html = '<h2>Another content</h2>';
-        $converter = new Block_Converter( $html );
-        $block     = $converter->convert();
+	public function test_convert_heading_h2_to_block() {
+		$html = '<h2>Another content</h2>';
+		$converter = new Block_Converter( $html );
+		$block     = $converter->convert();
 
-        $this->assertNotEmpty( $block );
-        $this->assertSame(
+		$this->assertNotEmpty( $block );
+		$this->assertSame(
 			'<!-- wp:heading {"level":2} -->' . $html . '<!-- /wp:heading -->',
 			$block,
-        );
-    }
+		);
+	}
 
-    public function test_convert_ol_to_block() {
-        $html = '<ol><li>Random content</li><li>Another random content</li></ol>';
-        $converter = new Block_Converter( $html );
-        $block     = $converter->convert();
+	public function test_convert_ol_to_block() {
+		$html = '<ol><li>Random content</li><li>Another random content</li></ol>';
+		$converter = new Block_Converter( $html );
+		$block     = $converter->convert();
 
-        $this->assertNotEmpty( $block );
-        $this->assertSame(
+		$this->assertNotEmpty( $block );
+		$this->assertSame(
 			'<!-- wp:list {"ordered":true} -->' . $html . '<!-- /wp:list -->',
 			$block,
 		);
-    }
+	}
 
-    public function test_convert_ul_to_block() {
-        $html = '<ul><li>Random content</li><li>Another random content</li></ul>';
-        $converter = new Block_Converter( $html );
-        $block     = $converter->convert();
+	public function test_convert_ul_to_block() {
+		$html = '<ul><li>Random content</li><li>Another random content</li></ul>';
+		$converter = new Block_Converter( $html );
+		$block     = $converter->convert();
 
-        $this->assertNotEmpty( $block );
-        $this->assertSame(
+		$this->assertNotEmpty( $block );
+		$this->assertSame(
 			"<!-- wp:list -->{$html}<!-- /wp:list -->",
 			$block,
-        );
-    }
+		);
+	}
 
-    public function test_convert_paragraphs_to_block() {
-        $converter = new Block_Converter( '<p>bar</p>' );
-        $block     = $converter->convert();
+	public function test_convert_paragraphs_to_block() {
+		$converter = new Block_Converter( '<p>bar</p>' );
+		$block     = $converter->convert();
 
-        $this->assertNotEmpty( $block );
-        $this->assertSame(
+		$this->assertNotEmpty( $block );
+		$this->assertSame(
 			'<!-- wp:paragraph --><p>bar</p><!-- /wp:paragraph -->',
 			$block,
-        );
-    }
+		);
+	}
 
-    public function test_convert_with_empty_paragraphs_to_block() {
-        $converter = new Block_Converter( '<p>bar</p><p></p>' );
-        $block     = $converter->convert();
+	public function test_convert_with_empty_paragraphs_to_block() {
+		$converter = new Block_Converter( '<p>bar</p><p></p>' );
+		$block     = $converter->convert();
 
-        $this->assertNotEmpty( $block );
-        $this->assertSame(
-            '<!-- wp:paragraph --><p>bar</p><!-- /wp:paragraph -->',
+		$this->assertNotEmpty( $block );
+		$this->assertSame(
+			'<!-- wp:paragraph --><p>bar</p><!-- /wp:paragraph -->',
 			$block,
-        );
-    }
+		);
+	}
 
-    public function test_convert_with_empty_paragraphs_of_arbitrary_length_to_block() {
-        $arbitraryNewLines = str_repeat( "\n\r", mt_rand( 1, 1000) );
-        $arbitrarySpaces = str_repeat( " ", mt_rand( 1, 1000 ) );
+	public function test_convert_with_empty_paragraphs_of_arbitrary_length_to_block() {
+		$arbitraryNewLines = str_repeat( "\n\r", mt_rand( 1, 1000) );
+		$arbitrarySpaces = str_repeat( " ", mt_rand( 1, 1000 ) );
 
-        $converter = new Block_Converter( '<p>bar</p><p></p><p>' . $arbitrarySpaces . $arbitraryNewLines . '</p>' );
-        $block     = $converter->convert();
+		$converter = new Block_Converter( '<p>bar</p><p></p><p>' . $arbitrarySpaces . $arbitraryNewLines . '</p>' );
+		$block     = $converter->convert();
 
-        $this->assertNotEmpty( $block );
-        $this->assertSame(
+		$this->assertNotEmpty( $block );
+		$this->assertSame(
 			$block,
 			'<!-- wp:paragraph --><p>bar</p><!-- /wp:paragraph -->',
-        );
-    }
+		);
+	}
 
 	public function test_convert_with_filter_override_single_tag() {
 		$this->expectApplied( 'wp_block_converter_document_html' )->once();
@@ -159,99 +159,112 @@ class Test_Block_Block_Converter extends Test_Case {
 		$this->assertSame( 'Override', $block );
 	}
 
-    public function test_youtube_url_to_embed() {
-        $this->fake_request( 'https://www.youtube.com/oembed?maxwidth=500&maxheight=750&url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DdQw4w9WgXcQ&dnt=1&format=json' )
-            ->with_response_code( 200 )
-            ->with_body( '{"title":"Rick Astley - Never Gonna Give You Up (Official Music Video)","author_name":"Rick Astley","author_url":"https://www.youtube.com/@RickAstleyYT","type":"video","height":281,"width":500,"version":"1.0","provider_name":"YouTube","provider_url":"https://www.youtube.com/","thumbnail_height":360,"thumbnail_width":480,"thumbnail_url":"https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg","html":"\u003ciframe width=\u0022500\u0022 height=\u0022281\u0022 src=\u0022https://www.youtube.com/embed/dQw4w9WgXcQ?feature=oembed\u0022 frameborder=\u00220\u0022 allow=\u0022accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\u0022 allowfullscreen title=\u0022Rick Astley - Never Gonna Give You Up (Official Music Video)\u0022\u003e\u003c/iframe\u003e"}' );
+	public function test_youtube_url_to_embed() {
+		$this->fake_request( 'https://www.youtube.com/oembed?maxwidth=500&maxheight=750&url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DdQw4w9WgXcQ&dnt=1&format=json' )
+			->with_response_code( 200 )
+			->with_body( '{"title":"Rick Astley - Never Gonna Give You Up (Official Music Video)","author_name":"Rick Astley","author_url":"https://www.youtube.com/@RickAstleyYT","type":"video","height":281,"width":500,"version":"1.0","provider_name":"YouTube","provider_url":"https://www.youtube.com/","thumbnail_height":360,"thumbnail_width":480,"thumbnail_url":"https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg","html":"\u003ciframe width=\u0022500\u0022 height=\u0022281\u0022 src=\u0022https://www.youtube.com/embed/dQw4w9WgXcQ?feature=oembed\u0022 frameborder=\u00220\u0022 allow=\u0022accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\u0022 allowfullscreen title=\u0022Rick Astley - Never Gonna Give You Up (Official Music Video)\u0022\u003e\u003c/iframe\u003e"}' );
 
-        $converter = new Block_Converter( '<p>https://www.youtube.com/watch?v=dQw4w9WgXcQ</p>' );
-        $block     = $converter->convert();
+		$converter = new Block_Converter( '<p>https://www.youtube.com/watch?v=dQw4w9WgXcQ</p>' );
+		$block     = $converter->convert();
 
-        $this->assertNotEmpty( $block );
-        $this->assertSame(
+		$this->assertNotEmpty( $block );
+		$this->assertSame(
 			'<!-- wp:embed {"url":"https://www.youtube.com/watch?v=dQw4w9WgXcQ","type":"video","providerNameSlug":"youtube","responsive":true,"className":"wp-embed-aspect-16-9 wp-has-aspect-ratio"} --><figure class="wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
 https://www.youtube.com/watch?v=dQw4w9WgXcQ
 </div></figure><!-- /wp:embed -->',
 			$block,
-        );
-    }
+		);
+	}
 
-    public function test_twitter_url_to_embed() {
-        $this->fake_request( 'https://publish.twitter.com/oembed?maxwidth=500&maxheight=750&url=https%3A%2F%2Ftwitter.com%2Falleyco%2Fstatus%2F1679189879086018562&dnt=1&format=json' )
-            ->with_response_code( 200 )
-            ->with_body( '{"url":"https:\/\/twitter.com\/alleyco\/status\/1679189879086018562","author_name":"Alley","author_url":"https:\/\/twitter.com\/alleyco","html":"\u003Cblockquote class=\"twitter-tweet\"\u003E\u003Cp lang=\"en\" dir=\"ltr\"\u003EWe’re a full-service digital agency with the foresight, perspective, and grit to power your brightest ideas and build solutions for your most evasive problems. Learn more about our services here:\u003Ca href=\"https:\/\/t.co\/8zZ5zP1Oyc\"\u003Ehttps:\/\/t.co\/8zZ5zP1Oyc\u003C\/a\u003E\u003C\/p\u003E&mdash; Alley (@alleyco) \u003Ca href=\"https:\/\/twitter.com\/alleyco\/status\/1679189879086018562?ref_src=twsrc%5Etfw\"\u003EJuly 12, 2023\u003C\/a\u003E\u003C\/blockquote\u003E\n\u003Cscript async src=\"https:\/\/platform.twitter.com\/widgets.js\" charset=\"utf-8\"\u003E\u003C\/script\u003E\n\n","width":550,"height":null,"type":"rich","cache_age":"3153600000","provider_name":"Twitter","provider_url":"https:\/\/twitter.com","version":"1.0"}' );
+	public function test_twitter_url_to_embed() {
+		$this->fake_request( 'https://publish.twitter.com/oembed?maxwidth=500&maxheight=750&url=https%3A%2F%2Ftwitter.com%2Falleyco%2Fstatus%2F1679189879086018562&dnt=1&format=json' )
+			->with_response_code( 200 )
+			->with_body( '{"url":"https:\/\/twitter.com\/alleyco\/status\/1679189879086018562","author_name":"Alley","author_url":"https:\/\/twitter.com\/alleyco","html":"\u003Cblockquote class=\"twitter-tweet\"\u003E\u003Cp lang=\"en\" dir=\"ltr\"\u003EWe’re a full-service digital agency with the foresight, perspective, and grit to power your brightest ideas and build solutions for your most evasive problems. Learn more about our services here:\u003Ca href=\"https:\/\/t.co\/8zZ5zP1Oyc\"\u003Ehttps:\/\/t.co\/8zZ5zP1Oyc\u003C\/a\u003E\u003C\/p\u003E&mdash; Alley (@alleyco) \u003Ca href=\"https:\/\/twitter.com\/alleyco\/status\/1679189879086018562?ref_src=twsrc%5Etfw\"\u003EJuly 12, 2023\u003C\/a\u003E\u003C\/blockquote\u003E\n\u003Cscript async src=\"https:\/\/platform.twitter.com\/widgets.js\" charset=\"utf-8\"\u003E\u003C\/script\u003E\n\n","width":550,"height":null,"type":"rich","cache_age":"3153600000","provider_name":"Twitter","provider_url":"https:\/\/twitter.com","version":"1.0"}' );
 
-        $converter = new Block_Converter( '<p>https://twitter.com/alleyco/status/1679189879086018562</p>' );
-        $block     = $converter->convert();
+		$converter = new Block_Converter( '<p>https://twitter.com/alleyco/status/1679189879086018562</p>' );
+		$block     = $converter->convert();
 
-        $this->assertNotEmpty( $block );
-        $this->assertSame(
-            '<!-- wp:embed {"url":"https://twitter.com/alleyco/status/1679189879086018562","type":"rich","providerNameSlug":"twitter","responsive":true} --><figure class="wp-block-embed is-type-rich is-provider-twitter wp-block-embed-twitter"><div class="wp-block-embed__wrapper">
+		$this->assertNotEmpty( $block );
+		$this->assertSame(
+			'<!-- wp:embed {"url":"https://twitter.com/alleyco/status/1679189879086018562","type":"rich","providerNameSlug":"twitter","responsive":true} --><figure class="wp-block-embed is-type-rich is-provider-twitter wp-block-embed-twitter"><div class="wp-block-embed__wrapper">
 https://twitter.com/alleyco/status/1679189879086018562
 </div></figure><!-- /wp:embed -->',
-            $block,
-        );
-    }
+			$block,
+		);
+	}
 
-    public function test_x_url_to_embed() {
-        $this->fake_request( 'https://publish.x.com/oembed?url=https%3A%2F%2Fx.com%2Falleyco%2Fstatus%2F1679189879086018562' )
-            ->with_response_code( 200 )
-            ->with_body( '{"url":"https:\/\/twitter.com\/alleyco\/status\/1679189879086018562","author_name":"Alley","author_url":"https:\/\/twitter.com\/alleyco","html":"\u003Cblockquote class=\"twitter-tweet\"\u003E\u003Cp lang=\"en\" dir=\"ltr\"\u003EWe’re a full-service digital agency with the foresight, perspective, and grit to power your brightest ideas and build solutions for your most evasive problems. Learn more about our services here:\u003Ca href=\"https:\/\/t.co\/8zZ5zP1Oyc\"\u003Ehttps:\/\/t.co\/8zZ5zP1Oyc\u003C\/a\u003E\u003C\/p\u003E&mdash; Alley (@alleyco) \u003Ca href=\"https:\/\/twitter.com\/alleyco\/status\/1679189879086018562?ref_src=twsrc%5Etfw\"\u003EJuly 12, 2023\u003C\/a\u003E\u003C\/blockquote\u003E\n\u003Cscript async src=\"https:\/\/platform.twitter.com\/widgets.js\" charset=\"utf-8\"\u003E\u003C\/script\u003E\n\n","width":550,"height":null,"type":"rich","cache_age":"3153600000","provider_name":"Twitter","provider_url":"https:\/\/twitter.com","version":"1.0"}' );
+	public function test_x_url_to_embed() {
+		$this->fake_request( 'https://publish.x.com/oembed?url=https%3A%2F%2Fx.com%2Falleyco%2Fstatus%2F1679189879086018562' )
+			->with_response_code( 200 )
+			->with_body( '{"url":"https:\/\/twitter.com\/alleyco\/status\/1679189879086018562","author_name":"Alley","author_url":"https:\/\/twitter.com\/alleyco","html":"\u003Cblockquote class=\"twitter-tweet\"\u003E\u003Cp lang=\"en\" dir=\"ltr\"\u003EWe’re a full-service digital agency with the foresight, perspective, and grit to power your brightest ideas and build solutions for your most evasive problems. Learn more about our services here:\u003Ca href=\"https:\/\/t.co\/8zZ5zP1Oyc\"\u003Ehttps:\/\/t.co\/8zZ5zP1Oyc\u003C\/a\u003E\u003C\/p\u003E&mdash; Alley (@alleyco) \u003Ca href=\"https:\/\/twitter.com\/alleyco\/status\/1679189879086018562?ref_src=twsrc%5Etfw\"\u003EJuly 12, 2023\u003C\/a\u003E\u003C\/blockquote\u003E\n\u003Cscript async src=\"https:\/\/platform.twitter.com\/widgets.js\" charset=\"utf-8\"\u003E\u003C\/script\u003E\n\n","width":550,"height":null,"type":"rich","cache_age":"3153600000","provider_name":"Twitter","provider_url":"https:\/\/twitter.com","version":"1.0"}' );
 
-        $converter = new Block_Converter( '<p>https://x.com/alleyco/status/1679189879086018562</p>' );
-        $block     = $converter->convert();
+		$converter = new Block_Converter( '<p>https://x.com/alleyco/status/1679189879086018562</p>' );
+		$block     = $converter->convert();
 
-        $this->assertNotEmpty( $block );
-        $this->assertSame(
-            '<!-- wp:embed {"url":"https://twitter.com/alleyco/status/1679189879086018562","type":"rich","providerNameSlug":"twitter","responsive":true} --><figure class="wp-block-embed is-type-rich is-provider-twitter wp-block-embed-twitter"><div class="wp-block-embed__wrapper">
+		$this->assertNotEmpty( $block );
+		$this->assertSame(
+			'<!-- wp:embed {"url":"https://twitter.com/alleyco/status/1679189879086018562","type":"rich","providerNameSlug":"twitter","responsive":true} --><figure class="wp-block-embed is-type-rich is-provider-twitter wp-block-embed-twitter"><div class="wp-block-embed__wrapper">
 https://twitter.com/alleyco/status/1679189879086018562
 </div></figure><!-- /wp:embed -->',
-            $block,
-        );
-    }
+			$block,
+		);
+	}
 
-    public function test_linked_x_url_to_embed() {
-        $this->fake_request( 'https://publish.x.com/oembed?url=https%3A%2F%2Fx.com%2Falleyco%2Fstatus%2F1679189879086018562' )
-            ->with_response_code( 200 )
-            ->with_body( '{"url":"https:\/\/twitter.com\/alleyco\/status\/1679189879086018562","author_name":"Alley","author_url":"https:\/\/twitter.com\/alleyco","html":"\u003Cblockquote class=\"twitter-tweet\"\u003E\u003Cp lang=\"en\" dir=\"ltr\"\u003EWe’re a full-service digital agency with the foresight, perspective, and grit to power your brightest ideas and build solutions for your most evasive problems. Learn more about our services here:\u003Ca href=\"https:\/\/t.co\/8zZ5zP1Oyc\"\u003Ehttps:\/\/t.co\/8zZ5zP1Oyc\u003C\/a\u003E\u003C\/p\u003E&mdash; Alley (@alleyco) \u003Ca href=\"https:\/\/twitter.com\/alleyco\/status\/1679189879086018562?ref_src=twsrc%5Etfw\"\u003EJuly 12, 2023\u003C\/a\u003E\u003C\/blockquote\u003E\n\u003Cscript async src=\"https:\/\/platform.twitter.com\/widgets.js\" charset=\"utf-8\"\u003E\u003C\/script\u003E\n\n","width":550,"height":null,"type":"rich","cache_age":"3153600000","provider_name":"Twitter","provider_url":"https:\/\/twitter.com","version":"1.0"}' );
+	public function test_linked_x_url_to_embed() {
+		$this->fake_request( 'https://publish.x.com/oembed?url=https%3A%2F%2Fx.com%2Falleyco%2Fstatus%2F1679189879086018562' )
+			->with_response_code( 200 )
+			->with_body( '{"url":"https:\/\/twitter.com\/alleyco\/status\/1679189879086018562","author_name":"Alley","author_url":"https:\/\/twitter.com\/alleyco","html":"\u003Cblockquote class=\"twitter-tweet\"\u003E\u003Cp lang=\"en\" dir=\"ltr\"\u003EWe’re a full-service digital agency with the foresight, perspective, and grit to power your brightest ideas and build solutions for your most evasive problems. Learn more about our services here:\u003Ca href=\"https:\/\/t.co\/8zZ5zP1Oyc\"\u003Ehttps:\/\/t.co\/8zZ5zP1Oyc\u003C\/a\u003E\u003C\/p\u003E&mdash; Alley (@alleyco) \u003Ca href=\"https:\/\/twitter.com\/alleyco\/status\/1679189879086018562?ref_src=twsrc%5Etfw\"\u003EJuly 12, 2023\u003C\/a\u003E\u003C\/blockquote\u003E\n\u003Cscript async src=\"https:\/\/platform.twitter.com\/widgets.js\" charset=\"utf-8\"\u003E\u003C\/script\u003E\n\n","width":550,"height":null,"type":"rich","cache_age":"3153600000","provider_name":"Twitter","provider_url":"https:\/\/twitter.com","version":"1.0"}' );
 
-        $converter = new Block_Converter( '<p><a href="https://x.com/alleyco/status/1679189879086018562">https://x.com/alleyco/status/1679189879086018562</a></p>' );
-        $block     = $converter->convert();
+		$converter = new Block_Converter( '<p><a href="https://x.com/alleyco/status/1679189879086018562">https://x.com/alleyco/status/1679189879086018562</a></p>' );
+		$block     = $converter->convert();
 
-        $this->assertNotEmpty( $block );
-        $this->assertSame(
-            '<!-- wp:embed {"url":"https://twitter.com/alleyco/status/1679189879086018562","type":"rich","providerNameSlug":"twitter","responsive":true} --><figure class="wp-block-embed is-type-rich is-provider-twitter wp-block-embed-twitter"><div class="wp-block-embed__wrapper">
+		$this->assertNotEmpty( $block );
+		$this->assertSame(
+			'<!-- wp:embed {"url":"https://twitter.com/alleyco/status/1679189879086018562","type":"rich","providerNameSlug":"twitter","responsive":true} --><figure class="wp-block-embed is-type-rich is-provider-twitter wp-block-embed-twitter"><div class="wp-block-embed__wrapper">
 https://twitter.com/alleyco/status/1679189879086018562
 </div></figure><!-- /wp:embed -->',
-            $block,
-        );
-    }
+			$block,
+		);
+	}
 
-    public function test_instagram_url_to_embed() {
-        $converter = new Block_Converter( '<p>https://www.instagram.com/p/CSpmSvAphdf/</p>' );
-        $block     = $converter->convert();
+	public function test_instagram_url_to_embed() {
+		$converter = new Block_Converter( '<p>https://www.instagram.com/p/CSpmSvAphdf/</p>' );
+		$block     = $converter->convert();
 
-        $this->assertNotEmpty( $block );
-        $this->assertSame(
-            '<!-- wp:embed {"url":"https://www.instagram.com/p/CSpmSvAphdf/","type":"rich","providerNameSlug":"instagram","responsive":true} --><figure class="wp-block-embed is-type-rich is-provider-instagram wp-block-embed-instagram"><div class="wp-block-embed__wrapper">
+		$this->assertNotEmpty( $block );
+		$this->assertSame(
+			'<!-- wp:embed {"url":"https://www.instagram.com/p/CSpmSvAphdf/","type":"rich","providerNameSlug":"instagram","responsive":true} --><figure class="wp-block-embed is-type-rich is-provider-instagram wp-block-embed-instagram"><div class="wp-block-embed__wrapper">
 https://www.instagram.com/p/CSpmSvAphdf/
 </div></figure><!-- /wp:embed -->',
-            $block,
-        );
-    }
+			$block,
+		);
+	}
 
-    public function test_facebook_url_to_embed() {
-        $converter = new Block_Converter( '<p>https://www.facebook.com/sesametheopossum/posts/1329405240877426</p>' );
-        $block     = $converter->convert();
+	public function test_facebook_url_to_embed() {
+		$converter = new Block_Converter( '<p>https://www.facebook.com/sesametheopossum/posts/1329405240877426</p>' );
+		$block     = $converter->convert();
 
-        $this->assertNotEmpty( $block );
-        $this->assertSame(
-            '<!-- wp:embed {"url":"https://www.facebook.com/sesametheopossum/posts/1329405240877426","type":"rich","providerNameSlug":"embed-handler","responsive":true,"previewable":false} --><figure class="wp-block-embed is-type-rich is-provider-embed-handler wp-block-embed-embed-handler"><div class="wp-block-embed__wrapper">
+		$this->assertNotEmpty( $block );
+		$this->assertSame(
+			'<!-- wp:embed {"url":"https://www.facebook.com/sesametheopossum/posts/1329405240877426","type":"rich","providerNameSlug":"embed-handler","responsive":true,"previewable":false} --><figure class="wp-block-embed is-type-rich is-provider-embed-handler wp-block-embed-embed-handler"><div class="wp-block-embed__wrapper">
 https://www.facebook.com/sesametheopossum/posts/1329405240877426
 </div></figure><!-- /wp:embed -->',
-            $block,
-        );
-    }
+			$block,
+		);
+	}
+
+	public function test_tiktok_url_to_embed() {
+		$converter = new Block_Converter( '<p>https://www.tiktok.com/@atribecalledval/video/7348705314746699054</p>' );
+		$block     = $converter->convert();
+
+		$this->assertNotEmpty( $block );
+		$this->assertSame(
+			'<!-- wp:embed {"url":"https://www.tiktok.com/@atribecalledval/video/7348705314746699054","type":"video","providerNameSlug":"tiktok","responsive":true} --><figure class="wp-block-embed is-type-video is-provider-tiktok wp-block-embed-tiktok"><div class="wp-block-embed__wrapper">
+https://www.tiktok.com/@atribecalledval/video/7348705314746699054
+</div></figure><!-- /wp:embed -->',
+			$block,
+		);
+	}
 
 	public function test_macroable() {
 		Block_Converter::macro(


### PR DESCRIPTION
**Issue Number:** #19

**Issue URL:** [embeds must have a line break before and after the url](https://github.com/alleyinteractive/wp-block-converter/issues/19)

### Description of the Change

- Fixed an issue where embeds do not display correctly on the front end if they do not have a line break before and after the URL.
- Implemented preservation of new lines in embed blocks to ensure accurate front-end display.

### How to Verify

1. Convert an embed and view it on the front end.
2. Edit the block to add line breaks before and after the URL.
3. Verify that the converted embed retains line breaks and displays correctly.

### Additional Notes

_No additional notes._